### PR TITLE
Fix to preserve capitalisation in find by jobcode

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -54,7 +54,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             return new FindCommand(new JobCodePredicate(jobCode));
         } else if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
             // Tag search
-            String tag = argMultimap.getValue(PREFIX_TAG).get();
+            String tag = ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get()).tagCode;
             return new FindCommand(new TagPredicate(Arrays.asList(tag)));
         } else if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             // Name search

--- a/src/main/java/seedu/address/model/person/JobCodePredicate.java
+++ b/src/main/java/seedu/address/model/person/JobCodePredicate.java
@@ -9,7 +9,7 @@ public class JobCodePredicate implements Predicate<Person> {
     private final String jobCode;
 
     public JobCodePredicate(String jobCode) {
-        this.jobCode = jobCode.toLowerCase(); // Make comparison case-insensitive
+        this.jobCode = jobCode;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/JobCodePredicate.java
+++ b/src/main/java/seedu/address/model/person/JobCodePredicate.java
@@ -14,8 +14,8 @@ public class JobCodePredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        // Compare job code exactly (case-insensitive)
-        return person.getJobCode().value.equalsIgnoreCase(jobCode);
+        // Compare job code exactly (case-sensitive)
+        return person.getJobCode().value.equals(jobCode);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -112,8 +112,6 @@ public class FindCommandParserTest {
         // Test parsing by name
         FindCommand expectedCommand = new FindCommand(new JobCodePredicate("SWE2024"));
         assertParseSuccess(parser, " j/SWE2024", expectedCommand);
-        assertParseSuccess(parser, " j/swe2024", expectedCommand);
-        assertParseSuccess(parser, " j/Swe2024", expectedCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/JobCodePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/JobCodePredicateTest.java
@@ -22,9 +22,9 @@ public class JobCodePredicateTest {
     }
 
     @Test
-    public void test_jobCodeDifferentCase_returnsTrue() {
+    public void test_jobCodeDifferentCase_returnsFalse() {
         JobCodePredicate predicate = new JobCodePredicate("eng123");
-        assertTrue(predicate.test(new PersonBuilder().withJobCode("ENG123").build()));
+        assertFalse(predicate.test(new PersonBuilder().withJobCode("ENG123").build()));
     }
 }
 


### PR DESCRIPTION
Fix to preserve capitalisation in find by jobcode

Fix to create exception for "Find t/" by using parseTag function