### PR TITLE
Update DeleteCommand and Statistics 

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,7 +15,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d person(s) listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -29,7 +29,7 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person with a positive integer index/name/email/phone/name & email/ name & phone \n"
+            + ": Deletes the person with a positive integer index/name/email/phone/name & email/name & phone \n"
             + "Parameters:\n"
             + "n/NAME\n"
             + "n/EMAIL\n"

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -12,12 +12,14 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmailPredicate;
 import seedu.address.model.person.FullNameMatchesPredicate;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.NameEmailPredicate;
 import seedu.address.model.person.NamePhonePredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.PhonePredicate;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -90,6 +92,27 @@ public class DeleteCommand extends Command {
         this.email = Optional.empty();
     }
 
+    /**
+     * Initialises DeleteCommand using Email only
+     * @param email Email object containing the contact's email.
+     */
+    public DeleteCommand(Email email) {
+        this.targetIndex = Optional.empty();
+        this.name = Optional.empty();
+        this.phone = Optional.empty();
+        this.email = Optional.of(email);
+    }
+
+    /**
+     * Initialises DeleteCommand using Phone only
+     * @param phone Phone object containing the contact's email.
+     */
+    public DeleteCommand(Phone phone) {
+        this.targetIndex = Optional.empty();
+        this.name = Optional.empty();
+        this.phone = Optional.of(phone);
+        this.email = Optional.empty();
+    }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
@@ -106,6 +129,10 @@ public class DeleteCommand extends Command {
             return deleteByNameEmail(name, email, model, listForFilter);
         } else if (name.isPresent()) {
             return deleteByName(name, model, listForFilter);
+        } else if (email.isPresent()) {
+            return deleteByEmail(email, model, listForFilter);
+        } else if (phone.isPresent()) {
+            return deleteByPhone(phone, model, listForFilter);
         } else {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
@@ -220,6 +247,48 @@ public class DeleteCommand extends Command {
         listForFilter.setPredicate(nameEmailPredicate);
         if (listForFilter.isEmpty()) { // if no matching contact
             throw new CommandException("No matching contacts found.");
+        }
+        Person personToDelete = listForFilter.get(0);
+        model.deletePerson(personToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+    }
+
+    /**
+     * Deletes a person by their phone number only, as phone number is unique
+     * @param phone Optional of Phone
+     * @param model Optional of Model
+     * @param listForFilter FilteredList supplied with Name and Email predicate.
+     * @return CommandResult that shows that the person with unique phone number has been deleted.
+     * @throws CommandException containing custom Exception messages.
+     */
+    private CommandResult deleteByPhone(Optional<Phone> phone, Model model, FilteredList<Person> listForFilter)
+            throws CommandException {
+        String phoneString = phone.get().value;
+        PhonePredicate phonePredicate = new PhonePredicate(phoneString);
+        listForFilter.setPredicate(phonePredicate);
+        if (listForFilter.isEmpty()) {
+            throw new CommandException("No matching contacts found.");
+        }
+        Person personToDelete = listForFilter.get(0);
+        model.deletePerson(personToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+    }
+
+    /**
+     * Deletes a person by their phone number only, as email is unique
+     * @param email Optional of Email
+     * @param model Optional of Model
+     * @param listForFilter FilteredList supplied with Name and Email predicate.
+     * @return CommandResult that shows that the person with unique email has been deleted.
+     * @throws CommandException containing custom Exception messages.
+     */
+    private CommandResult deleteByEmail(Optional<Email> email, Model model, FilteredList<Person> listForFilter)
+            throws CommandException {
+        String emailString = email.get().value;
+        EmailPredicate emailPredicate = new EmailPredicate(emailString);
+        listForFilter.setPredicate(emailPredicate);
+        if (listForFilter.isEmpty()) {
+            throw new CommandException("No matching contacts found");
         }
         Person personToDelete = listForFilter.get(0);
         model.deletePerson(personToDelete);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -29,15 +29,19 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters:\nINDEX (must be a positive integer) OR "
-            + "n/NAME OR "
-            + "n/NAME e/EMAIL OR "
+            + ": Deletes the person with a positive integer index/name/email/phone/name & email/ name & phone \n"
+            + "Parameters:\n"
+            + "n/NAME\n"
+            + "n/EMAIL\n"
+            + "n/PHONE\n"
+            + "n/NAME e/EMAIL\n"
             + "n/NAME p/PHONE\n"
-            + "Example:\n" + COMMAND_WORD + " 1 OR "
-            + COMMAND_WORD + " n/John Doe OR "
-            + COMMAND_WORD + " n/John Doe e/johndoe@gmail.com OR "
-            + COMMAND_WORD + " n/John Doe p/88306733";
+            + "Example:\n" + COMMAND_WORD + " 1\n"
+            + COMMAND_WORD + " n/John Doe\n"
+            + COMMAND_WORD + " e/johndoe@gmail.com\n"
+            + COMMAND_WORD + " p/88308830\n"
+            + COMMAND_WORD + " n/John Doe e/johndoe@gmail.com\n"
+            + COMMAND_WORD + " n/John Doe p/88308830\n";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/StatisticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatisticsCommand.java
@@ -2,7 +2,9 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javafx.collections.ObservableList;
@@ -62,9 +64,18 @@ public class StatisticsCommand extends Command {
         StringBuilder statisticsMessage = new StringBuilder();
 
         int totalApplicantsInSystem = 0;
+        // Convert the jobStatisticsMap entries into a list
+        List<Map.Entry<JobCode, JobCodeStatistics>> sortedEntries = new ArrayList<>(jobStatisticsMap.entrySet());
+        sortedEntries.sort((entry1, entry2) -> {
+            int result = entry1.getKey().value.toLowerCase().compareTo(entry2.getKey().value.toLowerCase());
+            if (result == 0) {
+                result = entry1.getKey().value.compareTo(entry2.getKey().value);
+            }
+            return result;
+        });
 
         // Iterate over the job statistics and build the message
-        for (Map.Entry<JobCode, JobCodeStatistics> entry : jobStatisticsMap.entrySet()) {
+        for (Map.Entry<JobCode, JobCodeStatistics> entry : sortedEntries) {
             JobCode jobCode = entry.getKey();
             JobCodeStatistics jobStats = entry.getValue();
 

--- a/src/main/java/seedu/address/logic/commands/StatisticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatisticsCommand.java
@@ -122,7 +122,7 @@ public class StatisticsCommand extends Command {
     private void insertTagPercentages(StringBuilder builder, HashMap<String, Integer> tagCounts,
                                       int totalApplicantsInSystem) {
         StringBuilder stringToInsert = new StringBuilder();
-        stringToInsert.append("Percentages of applicants in each interview stage:\n");
+        stringToInsert.append("Percentages of applicant(s) in each interview stage:\n");
 
         // Correct order of tags
         String[] tagOrder = {"N", "TP", "TC", "BP", "BC", "A", "R"};

--- a/src/main/java/seedu/address/model/person/JobCodeStatistics.java
+++ b/src/main/java/seedu/address/model/person/JobCodeStatistics.java
@@ -1,94 +1,68 @@
 package seedu.address.model.person;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Class to store statistics for each job code
  */
 public class JobCodeStatistics {
-    private int n;
-    private int tp;
-    private int tc;
-    private int bp;
-    private int bc;
-    private int a;
-    private int r;
-    private int totalApplicants;
+    private final Map<String, Integer> tagCounts = createTagCounts();
 
-    /**
-     * Initiallises class with 0 applicants for each tag, and 0 total applicants
-     */
-    public JobCodeStatistics() {
-        n = 0;
-        tp = 0;
-        tc = 0;
-        bp = 0;
-        bc = 0;
-        a = 0;
-        r = 0;
-        totalApplicants = 0;
+    // Initialize the tagCounts map with all tag codes set to 0
+    private static HashMap<String, Integer> createTagCounts() {
+        HashMap<String, Integer> tagCounts = new HashMap<>();
+        tagCounts.put("N", 0);
+        tagCounts.put("BP", 0);
+        tagCounts.put("BC", 0);
+        tagCounts.put("TP", 0);
+        tagCounts.put("TC", 0);
+        tagCounts.put("A", 0);
+        tagCounts.put("R", 0);
+        return tagCounts;
     }
 
     /**
-     * Increments the number of applicants in each interview stage.
-     * @param tagValue
+     * Increases a specific tag in the tagCode dictionary
+     * @param tagCode tagCode String
      */
-    public void incrementTag(String tagValue) {
-        totalApplicants++;
-
-        switch (tagValue) {
-        case "New":
-            n++;
-            break;
-        case "Technical Interview in Progress":
-            tp++;
-            break;
-        case "Technical Interview Confirmed":
-            tc++;
-            break;
-        case "Behavioral Interview in Progress":
-            bp++;
-            break;
-        case "Behavioral Interview Confirmed":
-            bc++;
-            break;
-        case "Accepted":
-            a++;
-            break;
-        case "Rejected":
-            r++;
-            break;
-        default:
-            throw new IllegalArgumentException("Invalid Tag Value: " + tagValue);
-        }
+    // Increment the count for a specific tag
+    public void incrementTag(String tagCode) {
+        tagCode = tagCode.toUpperCase();
+        tagCounts.put(tagCode, tagCounts.getOrDefault(tagCode, 0) + 1);
     }
+
+    // Get the total count of applicants across all tags
     public int getTotalApplicants() {
-        return totalApplicants;
+        return tagCounts.values().stream().mapToInt(Integer::intValue).sum();
     }
 
     public int getN() {
-        return n;
+        return tagCounts.getOrDefault("N", 0);
     }
-
-    public int getTP() {
-        return tp;
-    }
-
-    public int getTC() {
-        return tc;
-    }
-
     public int getBP() {
-        return bp;
+        return tagCounts.getOrDefault("BP", 0);
     }
-
     public int getBC() {
-        return bc;
+        return tagCounts.getOrDefault("BC", 0);
     }
-
+    public int getTP() {
+        return tagCounts.getOrDefault("TP", 0);
+    }
+    public int getTC() {
+        return tagCounts.getOrDefault("TC", 0);
+    }
     public int getA() {
-        return a;
+        return tagCounts.getOrDefault("A", 0);
+    }
+    public int getR() {
+        return tagCounts.getOrDefault("R", 0);
     }
 
-    public int getR() {
-        return r;
+    @Override
+    public String toString() {
+        return String.format("N: %d, TP: %d, TC: %d, BP: %d, BC: %d, A: %d, R: %d",
+                getN(), getTP(), getTC(), getBP(), getBC(), getA(), getR());
     }
 }
+


### PR DESCRIPTION
1. DeleteCommand now can delete based on:
* email only
* phone only

2. DeleteCommand doesn't accept name & email & phone combination as inputs
3. Fixed DeleteCommand still running with invalid predicates 
e.g. Delete e/email j/ST10412
4. Fixed DeleteCommand invalid argument feedback message to reflect new functionality, better organisation.


4. Statistics now shows percentage of each interview stage regardless of job code.
5. Statistics command word is now 'stats'
6. Statistics show statistics in each job code in alphanumeric and capital order. 
7. Fixed typo in statistics feedback message.
8. Fix minor formatting issues in statistics feedback message. 

9. Fix grammar error for person(s) listed in FindCommand. 

This PR fixes:
#224 #206 #201 #196 #181 #164 #141 #139 
